### PR TITLE
Fixed: Error while canceling order (BRA-160)

### DIFF
--- a/app/code/community/ADM/Warehouse/Model/Cataloginventory/Resource/Stock/Item/Collection.php
+++ b/app/code/community/ADM/Warehouse/Model/Cataloginventory/Resource/Stock/Item/Collection.php
@@ -30,7 +30,9 @@ class ADM_Warehouse_Model_CatalogInventory_Resource_Stock_Item_Collection extend
     {
         $this->getSelect()->join(array('stqt'=>$this->getTable('adm_warehouse/sales_item_quote')), 'main_table.stock_id=stqt.stock_id AND main_table.product_id=stqt.product_id', array('quote_qty'=>'stqt.qty'))
             ->where('quote_item_id=?', $item->getQuoteItemId());
-
+        
+        $this->getSelect()->group('item_id');
+        
         return $this;
     }
 


### PR DESCRIPTION
Error: Item (ADM_Warehouse_Model_Cataloginventory_Stock_Item) with the same id "1" already exist